### PR TITLE
Do not include EOL in Length entry of a Stream Dictionary

### DIFF
--- a/pydyf/__init__.py
+++ b/pydyf/__init__.py
@@ -320,7 +320,7 @@ class Stream(Object):
             compressobj = zlib.compressobj()
             stream = compressobj.compress(stream)
             stream += compressobj.flush()
-        extra['Length'] = len(stream) + 1
+        extra['Length'] = len(stream)
         return b'\n'.join((extra.data, b'stream', stream, b'endstream'))
 
 


### PR DESCRIPTION
PDF reference, version 1.7 says:

(Required) The number of bytes from the beginning of the line fol-
lowing the keyword stream to the last byte just before the keyword
endstream . (There may be an additional EOL marker, preceding
endstream , that is not included in the count and is not logically part
of the stream data.) See “Stream Extent,” above, for further discus-
sion.

I found this by running the VeraPDF tool (which does PDF/A validation). But this seems to be part of the PDF 1.7 reference as well. 