### PR TITLE
Add `v` and `y` operators

### DIFF
--- a/pydyf/__init__.py
+++ b/pydyf/__init__.py
@@ -141,6 +141,26 @@ class Stream(Object):
             _to_bytes(x2), _to_bytes(y2),
             _to_bytes(x3), _to_bytes(y3), b'c')))
 
+    def curve_start_to(self, x2, y2, x3, y3):
+        """Add cubic Bézier curve to current path
+
+        The curve shall extend to ``(x3, y3)`` using the current point and
+        ``(x2, y2)`` as the Bézier control points.
+        """
+        self.stream.append(b' '.join((
+            _to_bytes(x2), _to_bytes(y2),
+            _to_bytes(x3), _to_bytes(y3), b'v')))
+
+    def curve_end_to(self, x1, y1, x3, y3):
+        """Add cubic Bézier curve to current path
+
+        The curve shall extend to ``(x3, y3)`` using `(x1, y1)`` and ``(x3,
+        y3)`` as the Bézier control points.
+        """
+        self.stream.append(b' '.join((
+            _to_bytes(x1), _to_bytes(y1),
+            _to_bytes(x3), _to_bytes(y3), b'y')))
+
     def draw_x_object(self, reference):
         """Draw object given by reference."""
         self.stream.append(b'/' + _to_bytes(reference) + b' Do')

--- a/tests/test_pydyf.py
+++ b/tests/test_pydyf.py
@@ -217,6 +217,68 @@ def test_curve_to():
     ''')
 
 
+def test_curve_start_to():
+    document = pydyf.PDF()
+
+    draw = pydyf.Stream()
+    draw.move_to(2, 5)
+    draw.set_line_width(2)
+    draw.curve_start_to(3, 5, 5, 5)
+    draw.stroke()
+    document.add_object(draw)
+
+    document.add_page(pydyf.Dictionary({
+        'Type': '/Page',
+        'Parent': document.pages.reference,
+        'Contents': draw.reference,
+        'MediaBox': pydyf.Array([0, 0, 10, 10]),
+    }))
+
+    assert_pixels(document, '''
+        __________
+        __________
+        __________
+        __________
+        __KKK_____
+        __KKK_____
+        __________
+        __________
+        __________
+        __________
+    ''')
+
+
+def test_curve_end_to():
+    document = pydyf.PDF()
+
+    draw = pydyf.Stream()
+    draw.move_to(2, 5)
+    draw.set_line_width(2)
+    draw.curve_end_to(3, 5, 5, 5)
+    draw.stroke()
+    document.add_object(draw)
+
+    document.add_page(pydyf.Dictionary({
+        'Type': '/Page',
+        'Parent': document.pages.reference,
+        'Contents': draw.reference,
+        'MediaBox': pydyf.Array([0, 0, 10, 10]),
+    }))
+
+    assert_pixels(document, '''
+        __________
+        __________
+        __________
+        __________
+        __KKK_____
+        __KKK_____
+        __________
+        __________
+        __________
+        __________
+    ''')
+
+
 def test_transform():
     document = pydyf.PDF()
 


### PR DESCRIPTION
Add support for the `y` and `v` cubic Bézier path operators.

We are writing an svg path to pdf converter, using Pydyf to create the stream. The operators for the quadratic Bézier curves where missing, so I added them to your project.