### PR TITLE
Implement escaping for Strings

### DIFF
--- a/pydyf/__init__.py
+++ b/pydyf/__init__.py
@@ -375,7 +375,13 @@ class String(Object):
     @property
     def data(self):
         try:
-            return b'(' + _to_bytes(self.string) + b')'
+            # "A literal string is written as an arbitrary number of characters
+            # enclosed in parentheses. Any characters may appear in a string
+            # except unbalanced parentheses and the backslash, which must be
+            # treated specially."
+            escaped = _to_bytes(self.string).replace(
+                b'\\', b'\\\\').replace(b'(', b'\\(').replace(b')', b'\\)')
+            return b'(' + escaped + b')'
         except UnicodeEncodeError:
             encoded = BOM_UTF16_BE + str(self.string).encode('utf-16-be')
             return b'<' + encoded.hex().encode() + b'>'

--- a/tests/test_pydyf.py
+++ b/tests/test_pydyf.py
@@ -706,3 +706,6 @@ def test_string_encoding():
     assert pydyf.String('abc').data == b'(abc)'
     assert pydyf.String('déf').data == b'<feff006400e90066>'
     assert pydyf.String('♡').data == b'<feff2661>'
+    assert pydyf.String('\\abc').data == b'(\\\\abc)'
+    assert pydyf.String('abc(').data == b'(abc\\()'
+    assert pydyf.String('ab)c').data == b'(ab\\)c)'


### PR DESCRIPTION
We discovered a bug where unbalanced parentheses in a `\Title` string value would cause an invalid PDF to be generated.

Before:
```
$ echo '<title>abc(</title>' | weasyprint - test.pdf
$ qpdf --check test.pdf
checking test.pdf
PDF Version: 1.7
File is not encrypted
File is not linearized
WARNING: test.pdf (object 2 0, offset 92): EOF while reading token
WARNING: test.pdf (object 2 0, offset 858): unexpected EOF
WARNING: test.pdf (object 2 0, offset 858): parse error while reading object
WARNING: test.pdf (object 2 0, offset 858): expected endobj
WARNING: test.pdf (object 2 0, offset 858): EOF after endobj
```

After:
```
$ echo '<title>abc(</title>' | weasyprint - test.pdf
$ qpdf --check test.pdf
checking test.pdf
PDF Version: 1.7
File is not encrypted
File is not linearized
No syntax or stream encoding errors found; the file may still contain
errors that qpdf cannot detect
```
