### PR TITLE
adding 'pydyf'-object to Dictionary in 'common use cases - Display Images'  

### DIFF
--- a/docs/common_use_cases.rst
+++ b/docs/common_use_cases.rst
@@ -97,7 +97,7 @@ Display image
 
    document = pydyf.PDF()
 
-   extra = Dictionary({
+   extra = pydyf.Dictionary({
        'Type': '/XObject',
        'Subtype': '/Image',
        'Width': 197,

--- a/docs/example_accented_characters.py
+++ b/docs/example_accented_characters.py
@@ -1,0 +1,60 @@
+import pydyf
+
+document = pydyf.PDF()
+
+# Define the font
+font = pydyf.Dictionary({
+    'Type': '/Font',
+    'Subtype': '/Type1',
+    'Name': '/F1',
+    'BaseFont': '/Helvetica',
+    'Encoding': '/MacRomanEncoding',
+})
+
+
+document.add_object(font)
+
+# Set the font use for the text
+# Move to where to display the text
+# And display it
+text = pydyf.Stream()
+text.begin_text()
+text.set_font_size('F1', 10)
+text.text_matrix(1, 0, 0, 1, 10, 180)
+text.show_text(pydyf.String('Tête-à-tête på «Færøyene»?'.encode('mac_roman')))
+text.end_text()
+
+# Another line of text, this time colored
+text.begin_text()
+text.set_font_size('F1', 10)
+text.set_color_rgb(0, 0.7, 0.4)
+text.text_matrix(1, 0, 0, 1, 10, 160)
+text.show_text(pydyf.String('Argüição…  Łódź!'.encode('mac_roman', errors='replace')))  # Ł and ź are not available
+text.end_text()
+
+# Another line of text, this time colored
+text.begin_text()
+text.set_font_size('F1', 10)
+text.set_color_rgb(0.4, 0, 0.7)
+text.text_matrix(1, 0, 0, 1, 10, 140)
+text.show_text(pydyf.String('Saint-Andéol-le-Château. Freißenbüttel'.encode('mac_roman', errors='replace')))  # Ł and ź are not available
+text.end_text()
+
+document.add_object(text)
+
+# Put the font in the resources of the PDF
+document.add_page(pydyf.Dictionary({
+    'Type': '/Page',
+    'Parent': document.pages.reference,
+    'MediaBox': pydyf.Array([0, 0, 200, 200]),
+    'Contents': text.reference,
+    'Resources': pydyf.Dictionary({
+        'ProcSet': pydyf.Array(['/PDF', '/Text']),
+        'Font': pydyf.Dictionary({'F1': font.reference}),
+    })
+}))
+
+with open('../tests/document.pdf', 'wb') as f:
+    document.write(f)
+
+

--- a/docs/example_accented_characters.py
+++ b/docs/example_accented_characters.py
@@ -32,14 +32,6 @@ text.text_matrix(1, 0, 0, 1, 10, 160)
 text.show_text(pydyf.String('Argüição…  Łódź!'.encode('mac_roman', errors='replace')))  # Ł and ź are not available
 text.end_text()
 
-# Another line of text, this time colored
-text.begin_text()
-text.set_font_size('F1', 10)
-text.set_color_rgb(0.4, 0, 0.7)
-text.text_matrix(1, 0, 0, 1, 10, 140)
-text.show_text(pydyf.String('Saint-Andéol-le-Château. Freißenbüttel'.encode('mac_roman', errors='replace')))  # Ł and ź are not available
-text.end_text()
-
 document.add_object(text)
 
 # Put the font in the resources of the PDF


### PR DESCRIPTION
The example code for adding an image in 'common_use_cases.rst' does not work on my system. Changing `extra = Dictionary` into `extra = pydyf.Dictionary` solves the issue. This is coherent with the other examples.