### PR TITLE
Add standard compliant default identifier

### DIFF
--- a/pydyf/__init__.py
+++ b/pydyf/__init__.py
@@ -568,12 +568,11 @@ class PDF:
                 'Root': self.catalog.reference,
                 'Info': self.info.reference,
             }
-            if identifier is not None:
-                data = b''.join(
-                    obj.data for obj in self.objects if obj.free != 'f')
-                data_hash = md5(data).hexdigest().encode()
-                extra['ID'] = Array((
-                    String(identifier).data, String(data_hash).data))
+            data = b''.join(
+                obj.data for obj in self.objects if obj.free != 'f')
+            data_hash = md5(data).hexdigest().encode()
+            extra['ID'] = Array((
+                String(identifier or data_hash).data, String(data_hash).data))
             dict_stream = Stream([xref_stream], extra, compress)
             self.xref_position = dict_stream.offset = self.current_position
             self.add_object(dict_stream)
@@ -601,13 +600,12 @@ class PDF:
             self.write_line(f'/Size {len(self.objects)}'.encode(), output)
             self.write_line(b'/Root ' + self.catalog.reference, output)
             self.write_line(b'/Info ' + self.info.reference, output)
-            if identifier is not None:
-                data = b''.join(
-                    obj.data for obj in self.objects if obj.free != 'f')
-                data_hash = md5(data).hexdigest().encode()
-                self.write_line(
-                    b'/ID [' + String(identifier).data + b' ' +
-                    String(data_hash).data + b']', output)
+            data = b''.join(
+                obj.data for obj in self.objects if obj.free != 'f')
+            data_hash = md5(data).hexdigest().encode()
+            self.write_line(
+                b'/ID [' + String(identifier or data_hash).data + b' ' +
+                String(data_hash).data + b']', output)
             self.write_line(b'>>', output)
 
         self.write_line(b'startxref', output)

--- a/tests/test_pydyf.py
+++ b/tests/test_pydyf.py
@@ -1,4 +1,5 @@
 import io
+import re
 
 import pydyf
 
@@ -704,11 +705,24 @@ def test_text():
     ''')
 
 
-def test_identifier():
+def test_default_identifier():
+    document = pydyf.PDF()
+    pdf = io.BytesIO()
+    document.write(pdf, identifier=None)
+    assert re.search(
+        b'/ID \\[\\((?P<hash>[0-9a-f]{32})\\) \\((?P=hash)\\)\\]',
+        pdf.getvalue()
+    ) is not None
+
+
+def test_custom_identifier():
     document = pydyf.PDF()
     pdf = io.BytesIO()
     document.write(pdf, identifier=b'abc')
-    assert b'abc' in pdf.getvalue()
+    assert re.search(
+        b'/ID \\[\\(abc\\) \\(([0-9a-f]{32})\\)\\]',
+        pdf.getvalue()
+    ) is not None
 
 
 def test_version():

--- a/tests/test_pydyf.py
+++ b/tests/test_pydyf.py
@@ -705,10 +705,20 @@ def test_text():
     ''')
 
 
+def test_no_identifier():
+    document = pydyf.PDF()
+    pdf = io.BytesIO()
+    document.write(pdf, identifier=False)
+    assert re.search(
+        b'/ID \\[\\((?P<hash>[0-9a-f]{32})\\) \\((?P=hash)\\)\\]',
+        pdf.getvalue()
+    ) is None
+
+
 def test_default_identifier():
     document = pydyf.PDF()
     pdf = io.BytesIO()
-    document.write(pdf, identifier=None)
+    document.write(pdf, identifier=True)
     assert re.search(
         b'/ID \\[\\((?P<hash>[0-9a-f]{32})\\) \\((?P=hash)\\)\\]',
         pdf.getvalue()


### PR DESCRIPTION
To create standard-complying PDFs with an identifier, the current identifier option is not enough. The standard reads:

> File identifiers shall be defined by the optional ID entry in a PDF file’s trailer dictionary (see 7.5.5, “File Trailer”).
> The ID entry is optional but should be used. The value of this entry shall be an array of two byte strings. The
> first byte string shall be a permanent identifier based on the contents of the file at the time it was originally
> created and shall not change when the file is incrementally updated. The second byte string shall be a
> changing identifier based on the file’s contents at the time it was last updated. **When a file is first written, both**
> **identifiers shall be set to the same value.** If both identifiers match when a file reference is resolved, it is very
> likely that the correct and unchanged file has been found. If only the first identifier matches, a different version
> of the correct file has been found.
>
> To help ensure the uniqueness of file identifiers, they should be computed by means of a message digest
> algorithm such as MD5 (described in Internet RFC 1321, The MD5 Message-Digest Algorithm; see the
> Bibliography), using the following information:

(emphasis mine)

The second value of the ID array is always set to a hash of the document's objects. This is fine. But it's currently impossible to set the first value accordingly, because it's just not known before I create the document.

This PR creates an identifier by default, when identifier=None. It uses the same hash as the first component, as mandated by the spec. To create a new revision of the same document, the user can then take this ID from the original revision and pass it to the `identifier` argument - this will then create a new revision with proper IDs.

This will always create documents with identifiers, even though the ID in general is optional according to spec. I don't think that's a bad thing though. This goes in line with what is asked for here: https://github.com/Kozea/WeasyPrint/issues/1661 - PDF/A compliance by default.